### PR TITLE
Relaxed version requirement on setuptools.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools==1.1.4
+setuptools>=0.9.8
 wheel==0.21.0
 distlib==0.1.2
 urllib3>=1.7


### PR DESCRIPTION
I just tested it, and it seems to work perfectly with setuptools 0.9.8 .

0.9.8 is the version bundled with virtualenv, so that's one less dependency to install in a fersh virtualenv.
