### PR TITLE
Added a bootstrap command

### DIFF
--- a/.tox.sh
+++ b/.tox.sh
@@ -2,4 +2,4 @@
 
 # I'm just calling make from a file inside of the project to avoid getting an
 # annoying warning from tox.
-make
+VIRTUAL_ENV="fake_it_for_the_makefile" make

--- a/curdling/install.py
+++ b/curdling/install.py
@@ -72,6 +72,7 @@ class Install(SignalEmitter):
         self.index = self.conf.get('index')
         self.database = Database()
         self.logger = logger(__name__)
+        self.only_build = self.conf.get('only_build')
 
         # Used by the CLI tool
         self.update_retrieve_and_build = Signal()
@@ -290,7 +291,7 @@ class Install(SignalEmitter):
 
     def run(self):
         packages = self.retrieve_and_build()
-        if packages:
+        if packages and not self.only_build:
             self.install(packages)
         if not self.mapping.errors and self.conf.get('upload'):
             self.upload()

--- a/curdling/services/dependencer.py
+++ b/curdling/services/dependencer.py
@@ -9,6 +9,7 @@ class Dependencer(Service):
 
     def __init__(self, *args, **kwargs):
         super(Dependencer, self).__init__(*args, **kwargs)
+        self.ignore_extra = kwargs.get('ignore_extra')
         self.dependency_found = Signal()
 
     def handle(self, requester, data):
@@ -19,6 +20,8 @@ class Dependencer(Service):
         for spec in run_time_dependencies:
             # Packages might declare their "extras" here, so let's split it
             dependency, extra = (';' in spec and spec or spec + ';').split(';')
+            if extra and self.ignore_extra:
+                continue
             self.emit('dependency_found', self.name,
                       requirement=util.safe_name(dependency),
                       dependency_of=requirement)

--- a/curdling/tool/__init__.py
+++ b/curdling/tool/__init__.py
@@ -88,8 +88,8 @@ def progress(phrase, total, installed):
     percent = int((installed) / float(total) * 100.0)
     msg = [progress_bar(phrase, percent)]
     msg.append("({0}/{1})".format(installed, total))
-    sys.stdout.write(''.join(msg))
-    sys.stdout.flush()
+    sys.stderr.write(''.join(msg))
+    sys.stderr.flush()
 
 
 def build_and_retrieve_progress(total, retrieved, built, failed):
@@ -102,23 +102,23 @@ def build_and_retrieve_progress(total, retrieved, built, failed):
     else:
         msg.append("({0} requested, {1} retrieved, {2} processed)".format(
             total, retrieved, built))
-    sys.stdout.write(''.join(msg))
-    sys.stdout.flush()
+    sys.stderr.write(''.join(msg))
+    sys.stderr.flush()
 
 
 def show_report(failed=None):
     if failed:
-        sys.stdout.write('\nSome milk was spilled in the process:\n')
+        sys.stderr.write('\nSome milk was spilled in the process:\n')
     else:
-        sys.stdout.write('\n')
+        sys.stderr.write('\n')
     for package, errors in list((failed or {}).items()):
-        sys.stdout.write('{0}\n'.format(package))
+        sys.stderr.write('{0}\n'.format(package))
         for data in errors:
             exception = data['exception']
             parents = ', '.join(
                 ('from {0}'.format(d) if d else 'explicit requirement')
                 for d in data['dependency_of'])
-            sys.stdout.write(' * {0} ({1}): {2}:\n{3}\n'.format(
+            sys.stderr.write(' * {0} ({1}): {2}:\n{3}\n'.format(
                 data['requirement'],
                 parents,
                 exception.__class__.__name__,
@@ -200,7 +200,8 @@ def get_bootstrap_command(args):
             deps = list(deps)
             deps.remove('curdling')
             deps.append('curdling')
-            print(' '.join(index.get(pkg) for pkg in deps))
+            sys.stdout.write(' '.join(index.get(pkg) for pkg in deps))
+            sys.stdout.write('\n')
 
     cmd.connect('finished', print_bootstrap_wheels)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33
+envlist = py26, py27, py33
 
 [testenv]
 commands = ./.tox.sh


### PR DESCRIPTION
This new command builds all the wheels needed to install curd, and prints a list of those wheels. That way, they are ready for install in a new virtualenv.

This way, one can run `pip install $(curd bootstrap)` in a fresh virtualenv and have curd installed much faster than pip alone would have (30s vs 5s for me). This command could even be used as a virtualenvwrapper init script, since it's quite fast.
