### PR TITLE
Make storage and lock configurable for Index

### DIFF
--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, print_function, unicode_literals
-from mock import call, patch, Mock
-from nose.tools import nottest
+from mock import call, Mock
 
 from curdling.exceptions import VersionConflict, ReportableError
-from curdling.index import Index, PackageNotFound
+from curdling.index import Index, Storage
 from curdling.install import Install
 from curdling import install
 
@@ -30,7 +29,7 @@ def test_install_feed_when_theres_a_tarball_cached():
 
     # Given that I have a loaded local cache
     index = Index('')
-    index.storage = {'gherkin': {'0.1.0': ['storage1/gherkin-0.1.0.tar.gz']}}
+    index.storage = Storage({'gherkin': {'0.1.0': ['storage1/gherkin-0.1.0.tar.gz']}})
 
     # And that I have an environment associated with that local cache
     env = Install(conf={'index': index})
@@ -62,7 +61,7 @@ def test_install_feed_when_theres_a_wheel_cached():
 
     # Given that I have a loaded local cache
     index = Index('')
-    index.storage = {'gherkin': {'0.1.0': ['storage1/gherkin-0.1.0-py27-none-any.whl']}}
+    index.storage = Storage({'gherkin': {'0.1.0': ['storage1/gherkin-0.1.0-py27-none-any.whl']}})
 
     # And that I have an environment associated with that local cache
     env = Install(conf={'index': index})
@@ -94,7 +93,7 @@ def test_handle_requirement_finder():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
     install.pipeline()
 
@@ -114,7 +113,7 @@ def test_handle_link_download():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
     install.pipeline()
 
@@ -136,7 +135,7 @@ def test_handle_filter_compatible_requirements():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
 
     # And I mock the finder service end-point
@@ -161,7 +160,7 @@ def test_handle_filter_dups():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
 
     # And I mock the finder service end-point
@@ -186,7 +185,7 @@ def test_handle_filter_blacklisted_packages():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
 
     # And I mock the finder service end-point
@@ -205,7 +204,7 @@ def test_pipeline_update_mapping_stats():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
     install.pipeline()
 
@@ -227,7 +226,7 @@ def test_pipeline_update_mapping_errors():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
     install.pipeline()
 
@@ -268,7 +267,7 @@ def test_pipeline_finder_found_downloader():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
 
     # And I mock the downloader service end-point
@@ -317,7 +316,7 @@ def test_pipeline_downloader_tarzip_curdler():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
 
     # And I mock the curdler service end-point and start all the services
@@ -346,7 +345,7 @@ def test_pipeline_downloader_wheel_dependencer():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
 
     # And I mock the curdler service end-point and start all the services
@@ -375,7 +374,7 @@ def test_pipeline_curdler_wheel_dependencer():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
 
     # And I mock the curdler service end-point and start all the services
@@ -404,7 +403,7 @@ def test_pipeline_dependencer_queue():
 
     # Given that I have the install command
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
 
     # And I mock the curdler service end-point and start all the services
@@ -511,7 +510,7 @@ def test_load_installer_forward_errors():
 
     # Given that I have the install command with an empty index
     index = Index('')
-    index.storage = {}
+    index.storage = Storage()
     install = Install(conf={'index': index})
     install.pipeline()
 

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from mock import patch
-from curdling.index import Index, PackageNotFound
+from curdling.index import Index, PackageNotFound, Storage
 import os
 
 
@@ -52,24 +52,22 @@ def test_index_feed_backend():
     index.index('package.name-0.1.0.tar.gz')
 
     # Then I see that the backend structure looks right
-    dict(index.storage).should.equal({
-        'gherkin': {
-            '0.2.0': [
-                'gherkin-0.2.0.tar.gz',
-            ],
-            '0.1.5': [
-                'Gherkin-0.1.5.tar.gz',
-            ],
-            '0.1.0': [
-                'gherkin-0.1.0-py27-none-any.whl',
-                'gherkin-0.1.0.tar.gz',
-            ],
-        },
-        'package.name': {
-            '0.1.0': [
-                'package.name-0.1.0.tar.gz',
-            ]
-        }
+    dict(index.storage.get('gherkin')).should.equal({
+        '0.2.0': [
+            'gherkin-0.2.0.tar.gz',
+        ],
+        '0.1.5': [
+            'Gherkin-0.1.5.tar.gz',
+        ],
+        '0.1.0': [
+            'gherkin-0.1.0-py27-none-any.whl',
+            'gherkin-0.1.0.tar.gz',
+        ],
+    })
+    dict(index.storage.get('package.name')).should.equal({
+        '0.1.0': [
+            'package.name-0.1.0.tar.gz',
+        ]
     })
 
 
@@ -78,7 +76,7 @@ def test_index_get():
 
     # Given that I have an index loaded with a couple package references
     index = Index('')
-    index.storage = {
+    index.storage = Storage({
         'gherkin': {
             '0.2.0': [
                 'gherkin-0.2.0.tar.gz',
@@ -94,7 +92,7 @@ def test_index_get():
                 'gherkin-0.1.0-py27-none-any.whl',
             ],
         }
-    }
+    })
 
     # Let's do some random assertions
 
@@ -147,12 +145,31 @@ def test_index_get_corner_case_pkg_name():
 
     # Given that I have an index loaded with a couple package references
     index = Index('')
-    index.storage = {
+    index.storage = Storage({
         'python-gherkin': {
             '0.1.0': [
                 'python_gherkin-0.1.0.tar.gz',
             ]
         }
-     }
+     })
 
     index.get('python-gherkin==0.1.0;~whl').should.equal('python_gherkin-0.1.0.tar.gz')
+
+
+def test_storage_initialization():
+    "It should be able to initialize Storage with a dictionary"
+
+    storage = Storage({
+        'python-gherkin': {
+            '0.1.0': [
+                'python_gherkin-0.1.0.tar.gz',
+            ]
+        }
+    })
+
+    dict(storage.get('python-gherkin')).should.equal({
+        '0.1.0': [
+            'python_gherkin-0.1.0.tar.gz',
+        ]
+    })
+    storage.list_packages().should.equal(['python-gherkin'])


### PR DESCRIPTION
1.  `storage` become a `Storage` object;
2.  Inside `Index`, raw dictionary accesses of `storage` are replaced
   with method calls of `storage`, so that when we use some other class
   (probably a subclass of `Storage`) of
   object for `storage`, behaviors of these operations can be easily
   redefined.

If we want a `index` that can be accessed across multiple machines, we can create a `index` like this:

``` python
index = Index(curddir, MemcachedStorage())
```
