### PR TITLE
Let curd install sdist tarballs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ setuptools>=0.9.8
 wheel>=0.21.0
 distlib==0.1.2
 urllib3>=1.7
+pkginfo


### PR DESCRIPTION
This is a quick attempt at making curd support installing sdist tarballs like pip does:
```
asmundg@ike:/tmp/curdling(master⚡) » python setup.py sdist && curd install dist/curdling-0.4.0.tar.gz
```

It feels like a bit of a hack and the progress bar doesn't show up, so I'm probably doing something bad. Still, it actually does what I need it to do.