### PR TITLE
Add newer python version to tox and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - "2.7"
 #  - "3.2"
   - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 
 install: pip install -r development.txt
 script: make

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py26, py27, py32, py33
+envlist = py{26,27,32,33,34,35,36}
 
 [testenv]
 commands = ./.tox.sh
+deps =
+  py26: wheel==0.21.0


### PR DESCRIPTION
I'm updating [lettuce](https://github.com/gabrielfalcao/lettuce) and some related packages to python 3 so this is only to check that curdling is still working on newer versions of python.