### PR TITLE
Default pypi https

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - "2.7"
 #  - "3.2"
   - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 
 install: pip install -r development.txt
 script: make

--- a/curdling/tool/__init__.py
+++ b/curdling/tool/__init__.py
@@ -17,7 +17,7 @@ import sys
 
 
 DEFAULT_PYPI_INDEX_LIST = [
-    'http://pypi.python.org/simple/',
+    'https://pypi.python.org/simple/',
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py26, py27, py32, py33
+envlist = py{26,27,32,33,34,35,36}
 
 [testenv]
 commands = ./.tox.sh
+deps =
+  py26: wheel==0.21.0


### PR DESCRIPTION
http://pypi.python.org/simple/ didn't work any longer, now its always redirected to https version