### PR TITLE
Fix unicode reference

### DIFF
--- a/curdling/tool/__init__.py
+++ b/curdling/tool/__init__.py
@@ -236,7 +236,7 @@ def main():
         levels = [i for i in logging._levelToName.keys()
             if not isinstance(i, int) and i != 'NOTSET']
     parser.add_argument(
-        '-l', '--log-level', default='CRITICAL', choices=levels, type=unicode.upper,
+        '-l', '--log-level', default='CRITICAL', choices=levels, type=type('').upper,
         help='Log verbosity level (for nerds): {0}'.format(', '.join(levels)))
 
     parser.add_argument(


### PR DESCRIPTION
It breaks python3 support because `unicode` is not a valid name in python3.
The bug was introduced in c2321a1

I am not sure if this is the best way to access `unicode.upper` for py2
and `str.upper` in py3.
Probably would be better to use `six` or just make a lambda x: x.upper().