### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/curdling/services/downloader.py
+++ b/curdling/services/downloader.py
@@ -12,7 +12,7 @@ import tempfile
 import distlib.version
 
 
-# Hardcoded vaue for the size of the http pool used a couple times in this
+# Hardcoded value for the size of the http pool used a couple times in this
 # module. Not the perfect place, though might fix the ClosedPoolError we're
 # getting eventually.
 POOL_MAX_SIZE = 10
@@ -161,7 +161,7 @@ class PyPiLocator(locators.SimpleScrapingLocator, ComparableLocator):
         versions = {}
         page = self.get_page(url)
         for link, rel in (page and page.links or []):
-            # Let's instrospect one level down
+            # Let's introspect one level down
             if self._should_queue(link, url, rel) and not subvisit:
                 versions.update(self._fetch(link, project_name, subvisit=True))
 

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -28,7 +28,7 @@ def test_read_basic_fields():
     # When I parse it
     wheel = Wheel.from_file(wheel_file)
 
-    # Then I see that the wheel file was successfuly read
+    # Then I see that the wheel file was successfully read
     wheel.distribution.should.equal('gherkin')
     wheel.version.should.equal('0.1.0')
     wheel.build.should.be.none

--- a/tests/unit/test_freeze.py
+++ b/tests/unit/test_freeze.py
@@ -23,7 +23,7 @@ from mock import patch, Mock
 def test_find_imported_modules():
     "freeze.find_imported_modules() Should find all the imported modules in a string with Python code"
 
-    # Given the following snipet
+    # Given the following snippet
     code = '''
 import curdling
 
@@ -45,7 +45,7 @@ print(curdling)
 def test_find_imported_modules2():
     "freeze.find_imported_modules() Should also find imports declared with 'from x import y' syntax"
 
-    # Given the following snipet
+    # Given the following snippet
     code = '''
 from PIL import Image
 
@@ -67,7 +67,7 @@ print(curdling)
 def test_find_imported_modules4():
     "freeze.find_imported_modules() Should filter the module path when it has more than one level"
 
-    # Given the following snipet
+    # Given the following snippet
     code = '''
 from .relative import stuff
 '''
@@ -83,7 +83,7 @@ from .relative import stuff
 def test_find_imported_modules3():
     "freeze.find_imported_modules() Should skip any local imports (from . import x)"
 
-    # Given the following snipet
+    # Given the following snippet
     code = '''
 from . import Image
 import functools

--- a/tests/unit/test_mapping.py
+++ b/tests/unit/test_mapping.py
@@ -61,7 +61,7 @@ def test_available_versions():
     mapping.requirements.add('forbiddenfruit (<= 0.0.9)')
     mapping.wheels['forbiddenfruit (<= 0.0.9)'] = 'forbiddenfruit-0.0.9-cp27-none-macosx_10_8_x86_64.whl'
 
-    # And I add another random package to the maestrro
+    # And I add another random package to the maestro
     mapping.requirements.add('sure')
 
     # When I list all the available versions of forbidden fruit; Then I see it


### PR DESCRIPTION
There are small typos in:
- curdling/services/downloader.py
- tests/functional/test_wheel.py
- tests/unit/test_freeze.py
- tests/unit/test_mapping.py

Fixes:
- Should read `snippet` rather than `snipet`.
- Should read `value` rather than `vaue`.
- Should read `successfully` rather than `successfuly`.
- Should read `maestro` rather than `maestrro`.
- Should read `introspect` rather than `instrospect`.

Closes #92